### PR TITLE
add bépo layout (issue #513)

### DIFF
--- a/java/res/values-fr-rBP/donottranslate-keymap.xml
+++ b/java/res/values-fr-rBP/donottranslate-keymap.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2016, Abderrahim Kitouni
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+**
+**
+** 5-row layout for BÉPO (Dvorak-like layout for French).
+**
+** See https://github.com/klausw/hackerskeyboard/wiki/AddingNewLayouts for
+** more information.
+*/
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <string name="key_tlde_main">$</string>
+    <string name="key_tlde_shift">#</string>
+    <string name="key_tlde_alt">–¶</string>
+
+    <string name="key_ae01_main">\"</string>
+    <string name="key_ae01_shift">1</string>
+    <string name="key_ae01_alt">—„</string>
+
+    <string name="key_ae02_main">«</string>
+    <string name="key_ae02_shift">2</string>
+    <string name="key_ae02_alt">&lt;“</string>
+
+    <string name="key_ae03_main">»</string>
+    <string name="key_ae03_shift">3</string>
+    <string name="key_ae03_alt">&gt;”</string>
+
+    <string name="key_ae04_main">(</string>
+    <string name="key_ae04_shift">4</string>
+    <string name="key_ae04_alt">[≤</string>
+
+    <string name="key_ae05_main">)</string>
+    <string name="key_ae05_shift">5</string>
+    <string name="key_ae05_alt">]≥</string>
+
+    <string name="key_ae06_main">\@</string>
+    <string name="key_ae06_shift">6</string>
+    <string name="key_ae06_alt">^</string>
+
+    <string name="key_ae07_main">+</string>
+    <string name="key_ae07_shift">7</string>
+    <string name="key_ae07_alt">±¬</string>
+
+    <string name="key_ae08_main">-</string>
+    <string name="key_ae08_shift">8</string>
+    <string name="key_ae08_alt">−¼</string>
+
+    <string name="key_ae09_main">/</string>
+    <string name="key_ae09_shift">9</string>
+    <string name="key_ae09_alt">÷½</string>
+
+    <string name="key_ae10_main">*</string>
+    <string name="key_ae10_shift">0</string>
+    <string name="key_ae10_alt">×¾</string>
+
+    <string name="key_ae11_main">=</string>
+    <string name="key_ae11_shift">°</string>
+    <string name="key_ae11_alt">≠′</string>
+
+    <string name="key_ae12_main">%</string>
+    <string name="key_ae12_shift">`</string>
+    <string name="key_ae12_alt">‰″</string>
+
+
+    <string name="key_ad01_main">b</string>
+    <string name="key_ad01_shift">B</string>
+    <string name="key_ad01_alt">|¦</string>
+
+    <string name="key_ad02_main">é</string>
+    <string name="key_ad02_shift">É</string>
+    <string name="key_ad02_alt">\'˝</string> <!--TODO-->
+
+    <string name="key_ad03_main">p</string>
+    <string name="key_ad03_shift">P</string>
+    <string name="key_ad03_alt">&amp;§</string>
+
+    <string name="key_ad04_main">o</string>
+    <string name="key_ad04_shift">O</string>
+    <string name="key_ad04_alt">œŒ</string>
+
+    <string name="key_ad05_main">è</string>
+    <string name="key_ad05_shift">È</string>
+    <string name="key_ad05_alt">`</string><!--TODO-->
+
+    <string name="key_ad06_main">&#x302;</string>
+    <string name="key_ad06_shift">!</string>
+    <string name="key_ad06_alt">¡</string><!--TODO-->
+
+    <string name="key_ad07_main">v</string>
+    <string name="key_ad07_shift">V</string>
+    <string name="key_ad07_alt">ˇ</string><!--TODO-->
+
+    <string name="key_ad08_main">d</string>
+    <string name="key_ad08_shift">D</string>
+    <string name="key_ad08_alt">ðÐ</string>
+
+    <string name="key_ad09_main">l</string>
+    <string name="key_ad09_shift">L</string>
+    <string name="key_ad09_alt"></string><!--TODO-->
+
+    <string name="key_ad10_main">j</string>
+    <string name="key_ad10_shift">J</string>
+    <string name="key_ad10_alt">ĳĲ</string>
+
+    <string name="key_ad11_main">z</string>
+    <string name="key_ad11_shift">Z</string>
+    <string name="key_ad11_alt">əƏ</string>
+
+    <string name="key_ad12_main">w</string>
+    <string name="key_ad12_shift">W</string>
+    <string name="key_ad12_alt">˘</string><!--TODO-->
+
+    <string name="key_bksl_main">ç</string>
+    <string name="key_bksl_shift">Ç</string>
+    <string name="key_bksl_alt">¸,</string><!--TODO-->
+
+
+    <string name="key_ac01_main">a</string>
+    <string name="key_ac01_shift">A</string>
+    <string name="key_ac01_alt">æÆ</string>
+
+    <string name="key_ac02_main">u</string>
+    <string name="key_ac02_shift">U</string>
+    <string name="key_ac02_alt">ùÙ</string>
+
+    <string name="key_ac03_main">i</string>
+    <string name="key_ac03_shift">I</string>
+    <string name="key_ac03_alt">&#x308;˙</string><!--TODO-->
+
+    <string name="key_ac04_main">e</string>
+    <string name="key_ac04_shift">E</string>
+    <string name="key_ac04_alt">€¤</string><!--TODO-->
+
+    <string name="key_ac05_main">,</string>
+    <string name="key_ac05_shift">;</string>
+    <string name="key_ac05_alt">’̛</string><!--TODO-->
+
+    <string name="key_ac06_main">c</string>
+    <string name="key_ac06_shift">C</string>
+    <string name="key_ac06_alt">©ſ</string>
+
+    <string name="key_ac07_main">t</string>
+    <string name="key_ac07_shift">T</string>
+    <string name="key_ac07_alt">þÞ</string>
+
+    <string name="key_ac08_main">s</string>
+    <string name="key_ac08_shift">S</string>
+    <string name="key_ac08_alt">ßẞ</string>
+
+    <string name="key_ac09_main">r</string>
+    <string name="key_ac09_shift">R</string>
+    <string name="key_ac09_alt">®™</string>
+
+    <string name="key_ac10_main">n</string>
+    <string name="key_ac10_shift">N</string>
+    <string name="key_ac10_alt">~</string><!--TODO-->
+
+    <string name="key_ac11_main">m</string>
+    <string name="key_ac11_shift">M</string>
+    <string name="key_ac11_alt">¯º</string><!--TODO-->
+
+
+    <string name="key_lsgt_main">ê</string>
+    <string name="key_lsgt_shift">Ê</string>
+    <string name="key_lsgt_alt">/¦</string>
+
+    <string name="key_ab01_main">à</string>
+    <string name="key_ab01_shift">À</string>
+    <string name="key_ab01_alt">\\</string>
+
+    <string name="key_ab02_main">y</string>
+    <string name="key_ab02_shift">Y</string>
+    <string name="key_ab02_alt">{‘</string>
+
+    <string name="key_ab03_main">x</string>
+    <string name="key_ab03_shift">X</string>
+    <string name="key_ab03_alt">}’</string>
+
+    <string name="key_ab04_main">.</string>
+    <string name="key_ab04_shift">:</string>
+    <string name="key_ab04_alt">…·</string>
+
+    <string name="key_ab05_main">k</string>
+    <string name="key_ab05_shift">K</string>
+    <string name="key_ab05_alt">~</string>
+
+    <string name="key_ab06_main">\'</string>
+    <string name="key_ab06_shift">\?</string>
+    <string name="key_ab06_alt">¿̉</string><!--TODO-->
+
+    <string name="key_ab07_main">q</string>
+    <string name="key_ab07_shift">Q</string>
+    <string name="key_ab07_alt">°̣</string><!--TODO-->
+
+    <string name="key_ab08_main">g</string>
+    <string name="key_ab08_shift">G</string>
+    <string name="key_ab08_alt">µ</string><!--TODO-->
+
+    <string name="key_ab09_main">h</string>
+    <string name="key_ab09_shift">H</string>
+    <string name="key_ab09_alt">†‡</string>
+
+    <string name="key_ab10_main">f</string>
+    <string name="key_ab10_shift">F</string>
+    <string name="key_ab10_alt">˛ª</string><!--TODO-->
+</resources>

--- a/java/src/org/pocketworkstation/pckeyboard/InputLanguageSelection.java
+++ b/java/src/org/pocketworkstation/pckeyboard/InputLanguageSelection.java
@@ -68,17 +68,17 @@ public class InputLanguageSelection extends PreferenceActivity {
     // Run the GetLanguages.sh script to update the following lists based on
     // the available keyboard resources and dictionaries.
     private static final String[] KBD_LOCALIZATIONS = {
-        "ar", "bg", "bg_ST", "ca", "cs", "cs_QY", "da", "de", "de_NE",
-        "el", "en", "en_CX", "en_DV", "en_GB", "es", "es_LA", "es_US",
-        "fa", "fi", "fr", "fr_CA", "he", "hr", "hu", "hu_QY", "hy", "in",
-        "it", "iw", "ja", "ka", "ko", "lo", "lt", "lv", "nb", "nl", "pl",
-        "pt", "pt_PT", "rm", "ro", "ru", "ru_PH", "si", "sk", "sk_QY", "sl",
-        "sr", "sv", "ta", "th", "tl", "tr", "uk", "vi", "zh_CN", "zh_TW"
+        "ar", "bg", "bg_ST", "ca", "cs", "cs_QY", "da", "de", "de_NE", "el",
+        "en", "en_CX", "en_DV", "en_GB", "es", "es_LA", "es_US", "fa", "fi",
+        "fr", "fr_BP", "fr_CA", "he", "hr", "hu", "hu_QY", "hy", "in", "it",
+        "iw", "ja", "ko", "lo", "lt", "lv", "nb", "nl", "pl", "pt", "pt_PT",
+        "rm", "ro", "ru", "ru_PH", "si", "sk", "sk_QY", "sl", "sr", "sv",
+        "ta", "th", "tl", "tr", "uk", "vi", "zh_CN", "zh_TW"
     };
 
     private static final String[] KBD_5_ROW = {
-        "ar", "bg", "bg_ST", "cs", "cs_QY", "da", "de", "de_NE", "el",
-        "en", "en_CX", "en_DV", "en_GB", "es", "es_LA", "fa", "fi", "fr",
+        "ar", "bg", "bg_ST", "cs", "cs_QY", "da", "de", "de_NE", "el", "en",
+        "en_CX", "en_DV", "en_GB", "es", "es_LA", "fa", "fi", "fr", "fr_BP",
         "fr_CA", "he", "hr", "hu", "hu_QY", "hy", "it", "iw", "lo", "lt",
         "nb", "pt_PT", "ro", "ru", "ru_PH", "si", "sk", "sk_QY", "sl",
         "sr", "sv", "ta", "th", "tr", "uk"
@@ -106,6 +106,8 @@ public class InputLanguageSelection extends PreferenceActivity {
             return "Čeština (QWERTY)";
         } else if (lang.equals("de") && country.equals("NE")) {
             return "Deutsch (Neo2)";
+        } else if (lang.equals("fr") && country.equals("BP")) {
+            return "Français (BÉPO)";
         } else if (lang.equals("hu") && country.equals("QY")) {
             return "Magyar (QWERTY)";
         } else if (lang.equals("sk") && country.equals("QY")) {


### PR DESCRIPTION
This is missing the handling of dead keys (except the most basic ones). The bépo layout relies heavily on them for writing other European languages.