### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/java/src/org/pocketworkstation/pckeyboard/LatinKeyboardBaseView.java
+++ b/java/src/org/pocketworkstation/pckeyboard/LatinKeyboardBaseView.java
@@ -538,6 +538,9 @@ public class LatinKeyboardBaseView extends View implements PointerTracker.UIProx
                 break;
             }
         }
+		if (a != null) {
+			a.recycle();
+		}
 
         final Resources res = getResources();
 

--- a/java/src/org/pocketworkstation/pckeyboard/LatinKeyboardView.java
+++ b/java/src/org/pocketworkstation/pckeyboard/LatinKeyboardView.java
@@ -151,6 +151,9 @@ public class LatinKeyboardView extends LatinKeyboardBaseView {
                 break;
             }
         }
+		if (a != null) {
+			a.recycle();
+		}
 
         final Resources res = getResources();
         if (previewLayout != 0) {

--- a/java/src/org/pocketworkstation/pckeyboard/SeekBarPreference.java
+++ b/java/src/org/pocketworkstation/pckeyboard/SeekBarPreference.java
@@ -43,6 +43,9 @@ public class SeekBarPreference extends DialogPreference {
         mAsPercent = a.getBoolean(R.styleable.SeekBarPreference_asPercent, false);
         mLogScale = a.getBoolean(R.styleable.SeekBarPreference_logScale, false);
         mDisplayFormat = a.getString(R.styleable.SeekBarPreference_displayFormat);
+		if (a != null) {
+			a.recycle();
+		}
     }
 
     @Override


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis