### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/java/res/layout/input_stone_popup.xml
+++ b/java/res/layout/input_stone_popup.xml
@@ -1,45 +1,41 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-/*
-**
-** Copyright 2010, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
--->
+<?xml version='1.0' encoding='utf-8'?>
+  <!--
+  /*
+  **
+  ** Copyright 2010, The Android Open Source Project
+  **
+  ** Licensed under the Apache License, Version 2.0 (the "License");
+  ** you may not use this file except in compliance with the License.
+  ** You may obtain a copy of the License at
+  **
+  **     http://www.apache.org/licenses/LICENSE-2.0
+  **
+  ** Unless required by applicable law or agreed to in writing, software
+  ** distributed under the License is distributed on an "AS IS" BASIS,
+  ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ** See the License for the specific language governing permissions and
+  ** limitations under the License.
+  */
+  -->
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="horizontal"
+  android:background="@drawable/keyboard_popup_panel_background">
 
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:background="@drawable/keyboard_popup_panel_background"
-        >
-    <org.pocketworkstation.pckeyboard.LatinKeyboardBaseView
-            xmlns:latin="http://schemas.android.com/apk/res/org.pocketworkstation.pckeyboard"
-            android:id="@+id/LatinKeyboardBaseView"
-            android:layout_alignParentBottom="true"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/keyboard_background"
-
-            latin:keyBackground="@drawable/btn_keyboard_key_stone"
-            latin:keyTextColor="@color/latinkeyboard_key_color_black"
-            latin:keyHintColor="#FF777777"
-            latin:keyCursorColor="@color/latinkeyboard_dim_color_black"
-            latin:shadowColor="@color/latinkeyboard_key_color_white"
-            latin:recolorSymbols="true"
-            latin:keyPreviewLayout="@layout/null_layout"
-            latin:popupLayout="@layout/null_layout"
-        />
+  <org.pocketworkstation.pckeyboard.LatinKeyboardBaseView xmlns:latin="http://schemas.android.com/apk/res/org.pocketworkstation.pckeyboard"
+    android:id="@+id/LatinKeyboardBaseView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/keyboard_background"
+    latin:keyBackground="@drawable/btn_keyboard_key_stone"
+    latin:keyTextColor="@color/latinkeyboard_key_color_black"
+    latin:keyHintColor="#FF777777"
+    latin:keyCursorColor="@color/latinkeyboard_dim_color_black"
+    latin:shadowColor="@color/latinkeyboard_key_color_white"
+    latin:recolorSymbols="true"
+    latin:keyPreviewLayout="@layout/null_layout"
+    latin:popupLayout="@layout/null_layout">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentBottom-->
+  </org.pocketworkstation.pckeyboard.LatinKeyboardBaseView>
 </LinearLayout>

--- a/java/res/layout/keyboard_popup.xml
+++ b/java/res/layout/keyboard_popup.xml
@@ -1,43 +1,40 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-/*
-**
-** Copyright 2010, The Android Open Source Project
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-*/
--->
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:background="@drawable/keyboard_popup_panel_background"
-        android:paddingLeft="16dip"
-        android:paddingRight="16dip"
-        >
-    <org.pocketworkstation.pckeyboard.LatinKeyboardBaseView
-            xmlns:latin="http://schemas.android.com/apk/res/org.pocketworkstation.pckeyboard"
-            android:id="@+id/LatinKeyboardBaseView"
-            android:layout_alignParentBottom="true"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/latinkeyboard_transparent"
+<?xml version='1.0' encoding='utf-8'?>
+  <!--
+  /*
+  **
+  ** Copyright 2010, The Android Open Source Project
+  **
+  ** Licensed under the Apache License, Version 2.0 (the "License");
+  ** you may not use this file except in compliance with the License.
+  ** You may obtain a copy of the License at
+  **
+  **     http://www.apache.org/licenses/LICENSE-2.0
+  **
+  ** Unless required by applicable law or agreed to in writing, software
+  ** distributed under the License is distributed on an "AS IS" BASIS,
+  ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ** See the License for the specific language governing permissions and
+  ** limitations under the License.
+  */
+  -->
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:orientation="horizontal"
+  android:background="@drawable/keyboard_popup_panel_background"
+  android:paddingLeft="16dip"
+  android:paddingRight="16dip">
 
-            latin:keyBackground="@drawable/btn_keyboard_key_gingerbread_popup"
-            latin:keyHysteresisDistance="0dip"
-            latin:verticalCorrection="@dimen/mini_keyboard_vertical_correction"
-            latin:keyPreviewLayout="@layout/null_layout"
-            latin:popupLayout="@layout/null_layout"
-            />
+  <org.pocketworkstation.pckeyboard.LatinKeyboardBaseView xmlns:latin="http://schemas.android.com/apk/res/org.pocketworkstation.pckeyboard"
+    android:id="@+id/LatinKeyboardBaseView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/latinkeyboard_transparent"
+    latin:keyBackground="@drawable/btn_keyboard_key_gingerbread_popup"
+    latin:keyHysteresisDistance="0dip"
+    latin:verticalCorrection="@dimen/mini_keyboard_vertical_correction"
+    latin:keyPreviewLayout="@layout/null_layout"
+    latin:popupLayout="@layout/null_layout">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentBottom-->
+  </org.pocketworkstation.pckeyboard.LatinKeyboardBaseView>
 </LinearLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis