### PR TITLE
Build request

### DIFF
--- a/java/src/org/pocketworkstation/pckeyboard/LatinIME.java
+++ b/java/src/org/pocketworkstation/pckeyboard/LatinIME.java
@@ -381,7 +381,7 @@ public class LatinIME extends InputMethodService implements
         // setStatusIcon(R.drawable.ime_qwerty);
         mResources = getResources();
         final Configuration conf = mResources.getConfiguration();
-        mOrientation = conf.orientation;
+        mOrientation = conf.screenWidthDp<480 ? Configuration.ORIENTATION_PORTRAIT : Configuration.ORIENTATION_LANDSCAPE;
         final SharedPreferences prefs = PreferenceManager
                 .getDefaultSharedPreferences(this);
         mLanguageSwitcher = new LanguageSwitcher(this);
@@ -445,7 +445,7 @@ public class LatinIME extends InputMethodService implements
             }
         }
 
-        mOrientation = conf.orientation;
+        mOrientation = conf.screenWidthDp<480 ? Configuration.ORIENTATION_PORTRAIT : Configuration.ORIENTATION_LANDSCAPE;
 
         // register to receive ringer mode changes for silent mode
         IntentFilter filter = new IntentFilter(
@@ -667,7 +667,7 @@ public class LatinIME extends InputMethodService implements
             commitTyped(ic, true);
             if (ic != null)
                 ic.finishComposingText(); // For voice input
-            mOrientation = conf.orientation;
+            mOrientation = conf.screenWidthDp<480 ? Configuration.ORIENTATION_PORTRAIT : Configuration.ORIENTATION_LANDSCAPE;
             reloadKeyboards();
             removeCandidateViewContainer();
         }


### PR DESCRIPTION
Hi,

First of all, thanks for this nice keyboard!

Second, may I ask you to make a custom build for me with the suggested change? I believe it will be useful only for me, but since I can't build myself - I'm asking for your help. You can get the sources from my repository: https://github.com/Lex-2008/hackerskeyboard.git or from this PR.

My story: to ease SSH'ing on the go, I bought a dual-screen NEC N05-e phone, which can work either as 4" 540x960px (360x640dp) phone, or, when unfolded, as 5.42" 960x1080px (598x768dp) tablet. In both cases it can be in "portrait" and "landscape" mode, but I want the Hacker's Keyboard to use 4-row layout only when the device is in "phone" mode - on other words, to make the keyboard layout (or landscape/portrait orientation in the keyboard's understanding) depend not on sensor, but on actual screen width, hence this commit.

Once again: this is a request to build a custom version for me, not a request to integrate this code to official Hacker's Keyboard :)