### PR TITLE
Added code to make all the screens secure

### DIFF
--- a/java/src/org/pocketworkstation/pckeyboard/InputLanguageSelection.java
+++ b/java/src/org/pocketworkstation/pckeyboard/InputLanguageSelection.java
@@ -147,6 +147,7 @@ public class InputLanguageSelection extends PreferenceActivity {
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        Keyboard.setFlagSecure(this);
         addPreferencesFromResource(R.xml.language_prefs);
         // Get the settings preferences
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);

--- a/java/src/org/pocketworkstation/pckeyboard/Keyboard.java
+++ b/java/src/org/pocketworkstation/pckeyboard/Keyboard.java
@@ -29,6 +29,9 @@ import android.util.TypedValue;
 import android.util.Xml;
 import android.util.DisplayMetrics;
 
+import android.app.Activity;
+import android.view.WindowManager;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -1307,6 +1310,17 @@ public class Keyboard {
             return a.getFraction(index, base, base, defValue);
         }
         return defValue;
+    }
+
+    /**
+     * Method to set FLAG_SECURE inside activities
+     *
+     * @param activity
+     * @see <a href="https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE">FLAG_SECURE</a>
+     */
+    public static void setFlagSecure(Activity activity) {
+        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE);
     }
 
     @Override

--- a/java/src/org/pocketworkstation/pckeyboard/LatinIMEDebugSettings.java
+++ b/java/src/org/pocketworkstation/pckeyboard/LatinIMEDebugSettings.java
@@ -35,6 +35,7 @@ public class LatinIMEDebugSettings extends PreferenceActivity
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        Keyboard.setFlagSecure(this);
         addPreferencesFromResource(R.xml.prefs_for_debug);
         SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
         prefs.registerOnSharedPreferenceChangeListener(this);

--- a/java/src/org/pocketworkstation/pckeyboard/LatinIMESettings.java
+++ b/java/src/org/pocketworkstation/pckeyboard/LatinIMESettings.java
@@ -63,6 +63,7 @@ public class LatinIMESettings extends PreferenceActivity
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        Keyboard.setFlagSecure(this);
         addPreferencesFromResource(R.xml.prefs);
         mQuickFixes = (CheckBoxPreference) findPreference(QUICK_FIXES_KEY);
         mVoicePreference = (ListPreference) findPreference(VOICE_SETTINGS_KEY);

--- a/java/src/org/pocketworkstation/pckeyboard/Main.java
+++ b/java/src/org/pocketworkstation/pckeyboard/Main.java
@@ -40,6 +40,7 @@ public class Main extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
+        Keyboard.setFlagSecure(this);
         String html = getString(R.string.main_body);
         html += "<p><i>Version: " + getString(R.string.auto_version) + "</i></p>";
         Spanned content = Html.fromHtml(html);
@@ -62,7 +63,7 @@ public class Main extends Activity {
                 mgr.showInputMethodPicker();
             }
         });
-        
+
         final Activity that = this;
 
         final Button setup4 = (Button) findViewById(R.id.main_setup_btn_input_lang);
@@ -77,16 +78,16 @@ public class Main extends Activity {
             public void onClick(View v) {
                 Intent it = new Intent(Intent.ACTION_VIEW, Uri.parse(MARKET_URI));
                 try {
-                	startActivity(it);
+                    startActivity(it);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getApplicationContext(),
                             getResources().getString(
-                            		R.string.no_market_warning), Toast.LENGTH_LONG)
+                                    R.string.no_market_warning), Toast.LENGTH_LONG)
                             .show();
                 }
             }
         });
         // PluginManager.getPluginDictionaries(getApplicationContext()); // why?
-    }    
+    }
 }
 

--- a/java/src/org/pocketworkstation/pckeyboard/PrefScreenActions.java
+++ b/java/src/org/pocketworkstation/pckeyboard/PrefScreenActions.java
@@ -27,6 +27,7 @@ public class PrefScreenActions extends PreferenceActivity
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        Keyboard.setFlagSecure(this);
         addPreferencesFromResource(R.xml.prefs_actions);
         SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
         prefs.registerOnSharedPreferenceChangeListener(this);

--- a/java/src/org/pocketworkstation/pckeyboard/PrefScreenFeedback.java
+++ b/java/src/org/pocketworkstation/pckeyboard/PrefScreenFeedback.java
@@ -28,6 +28,7 @@ public class PrefScreenFeedback extends PreferenceActivity
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        Keyboard.setFlagSecure(this);
         addPreferencesFromResource(R.xml.prefs_feedback);
         SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
         prefs.registerOnSharedPreferenceChangeListener(this);

--- a/java/src/org/pocketworkstation/pckeyboard/PrefScreenView.java
+++ b/java/src/org/pocketworkstation/pckeyboard/PrefScreenView.java
@@ -30,6 +30,7 @@ public class PrefScreenView extends PreferenceActivity
     @Override
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        Keyboard.setFlagSecure(this);
         addPreferencesFromResource(R.xml.prefs_view);
         SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
         prefs.registerOnSharedPreferenceChangeListener(this);


### PR DESCRIPTION
Added FLAG_SECURE to all the Activities so that no screenshots can be captured. For further information about FLAG_SECURE, read [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE) .