### PR TITLE
Wiki - Update code.google to GitHub links.

### DIFF
--- a/AddingNewLayouts.md
+++ b/AddingNewLayouts.md
@@ -1,6 +1,6 @@
 # Adding new keyboard layouts #
 
-_**Warning:** I'm currently in the middle of a refactoring that will replace the current complex XML layout definitions with simple text files. If you're thinking about starting work on a layout based on the instructions below, you may want to wait for the new system - see [issue 13](https://code.google.com/p/hackerskeyboard/issues/detail?id=13)._
+_**Warning:** I'm currently in the middle of a refactoring that will replace the current complex XML layout definitions with simple text files. If you're thinking about starting work on a layout based on the instructions below, you may want to wait for the new system - see [issue 13](https://github.com/klausw/hackerskeyboard/issues/13)._
 
 It's very difficult for me to create and test keyboard layouts for languages I can't read or write. Help in improving support for additional languages would be very much appreciated.
 
@@ -21,18 +21,18 @@ There are three parts needed for fully supporting a new layout:
   * "alternates" definitions used to populate the long-press popup mini-keyboard contents
   * a 5-row layout, used for tablets, or in landscape mode
 
-The 4-row keyboards each have a `kbd_qwerty.xml` file defining the key configuration and characters, for example [kbd\_qwerty.xml](http://code.google.com/p/hackerskeyboard/source/browse/java/res/xml-de/kbd_qwerty.xml) for the German QWERTZ layout. If a language doesn't currently have a 4-row layout, that would need to be adapted and added.
+The 4-row keyboards each have a `kbd_qwerty.xml` file defining the key configuration and characters, for example [kbd\_qwerty.xml](https://github.com/klausw/hackerskeyboard/blob/master/java/res/xml-de/kbd_qwerty.xml) for the German QWERTZ layout. If a language doesn't currently have a 4-row layout, that would need to be adapted and added.
 
 The per-letter alternate characters shown in long-press popups are based on a language-specific `donottranslate-altchars.xml` file. This includes the digits shown in the top row of the 4-row keyboard.
 
 The 5-row keyboard layouts are configured separately from the standard Gingerbread 4-row keyboards.
 
-The core 5-row layout is defined in the [kbd\_full.xml](http://code.google.com/p/hackerskeyboard/source/browse/java/res/xml/kbd_full.xml) file, it defines key sizes and positions but not the characters shown on each key, so it should not need to be modified by language. The character mappings are defined per language in the `donottranslate-keymap.xml` file, assigning characters for each key position.
+The core 5-row layout is defined in the [kbd\_full.xml](https://github.com/klausw/hackerskeyboard/blob/master/java/res/xml/kbd_full.xml) file, it defines key sizes and positions but not the characters shown on each key, so it should not need to be modified by language. The character mappings are defined per language in the `donottranslate-keymap.xml` file, assigning characters for each key position.
 
 Examples for the language-specific mappings:
-  * English QWERTY [4-row layout](http://code.google.com/p/hackerskeyboard/source/browse/java/res/xml/kbd_qwerty.xml), [5-row keymap](http://code.google.com/p/hackerskeyboard/source/browse/java/res/values/donottranslate-keymap.xml) and [altchars](http://code.google.com/p/hackerskeyboard/source/browse/java/res/values/donottranslate-altchars.xml)
-  * German QWERTZ [4-row layout](http://code.google.com/p/hackerskeyboard/source/browse/java/res/xml-de/kbd_qwerty.xml), [keymap](http://code.google.com/p/hackerskeyboard/source/browse/java/res/values-de/donottranslate-keymap.xml) and [altchars](http://code.google.com/p/hackerskeyboard/source/browse/java/res/values-de/donottranslate-altchars.xml)
-  * Russian [4-row layout](http://code.google.com/p/hackerskeyboard/source/browse/java/res/xml-ru/kbd_qwerty.xml), [keymap](http://code.google.com/p/hackerskeyboard/source/browse/java/res/values-ru/donottranslate-keymap.xml)
+  * English QWERTY [4-row layout](https://github.com/klausw/hackerskeyboard/blob/master/java/res/xml/kbd_qwerty.xml), [5-row keymap](https://github.com/klausw/hackerskeyboard/blob/master/java/res/values/donottranslate-keymap.xml) and [altchars](https://github.com/klausw/hackerskeyboard/blob/master/java/res/values/donottranslate-altchars.xml)
+  * German QWERTZ [4-row layout](https://github.com/klausw/hackerskeyboard/blob/master/java/res/xml-de/kbd_qwerty.xml), [keymap](https://github.com/klausw/hackerskeyboard/blob/master/java/res/values-de/donottranslate-keymap.xml) and [altchars](https://github.com/klausw/hackerskeyboard/blob/master/java/res/values-de/donottranslate-altchars.xml)
+  * Russian [4-row layout](https://github.com/klausw/hackerskeyboard/blob/master/java/res/xml-ru/kbd_qwerty.xml), [keymap](https://github.com/klausw/hackerskeyboard/blob/master/java/res/values-ru/donottranslate-keymap.xml)
 
 ## Editing the keymap.xml file ##
 

--- a/BuildingFromSource.md
+++ b/BuildingFromSource.md
@@ -1,10 +1,6 @@
 _Instructions originally contributed by Christian Holm Christensen, thank you!_
 
-You can get the sources for the app at
-
-> hg clone https://code.google.com/p/hackerskeyboard/
-
-(Mercurial repository).
+You can get the sources for the app from Github as usual.
 
 ## Developing using Android Studio ##
 
@@ -35,12 +31,7 @@ Then, you should get the Android Development Tool (ADT) plug-in at
 
 > http://developer.android.com/sdk/eclipse-adt.html
 
-To be effective, you should get the Mercurial plug-in
-
-> http://www.javaforge.com/project/HGE#download
-
-Now, use the _File->New->Project..._ wizard, selecting
-_Mercurial->Clone ..._ to check out the sources into your workspace.
+To be effective, you should use the Git plug-in
 
 Note, that this will check out a directory structure that doesn't really correspond to the directory structure expected by the ADT plug-in. You should therefore use the _File->New->Android Project_ wizard to set up another project.  Make sure you select _Create Project from existing sources_ and select the sub-directory _java_ of the sources you check out before.  The project settings should be filled out automatically - except the project name - it could be something like 'my-hackerskeyboard'
 
@@ -52,33 +43,21 @@ Now, clean the project (perhaps twice) and run the app.
 
 ## Other stuff ##
 
-### Make Mercurial ignore some (generated) files ###
+### Make Git ignore some (generated) files ###
 
-Perhaps you want to add the file _.hgignore_ in your check-out directory with content like
+Perhaps you want to add the file _.gitignore_ in your check-out directory with content like
 
 ```
-        syntax: regexp
-        ^java/bin$
-        ^java/obj$
-        ^java/gen$
-        ^java/libs$
-        ^java/.classpath$
-        ^java/.project$
-        ^java/default.properties$
-        ^.project$
+        java/bin
+        java/obj
+        java/gen
+        java/libs
+        java/.classpath
+        java/.project
+        java/default.properties
+        .project
 ```
 
-so that you do not get 'funny' output from 'hg status' or the like
-
-### Making Changes ###
-
-Creating patches:
-
-> hg diff -w > my\_patch.patch
-
-Applying patches:
-
-> patch . < my\_patch.patch
-
+so that you do not get 'funny' output from 'git status' or the like
 
 Happy coding.

--- a/FrequentlyAskedQuestions.md
+++ b/FrequentlyAskedQuestions.md
@@ -8,13 +8,13 @@ This warning is a general Android system security feature that alerts users when
 
 A keyboard knows which keys you are currently typing (that's part of its job description), and a malicious application could abuse that, especially if it were to ask for Internet access permission.
 
-The source code for this project is available at the [Source](http://code.google.com/p/hackerskeyboard/source/checkout) link above, you are welcome to review it and/or build your own binary.
+The source code for this project is available at the [Source](https://github.com/klausw/hackerskeyboard) link above, you are welcome to review it and/or build your own binary.
 
 In case you're curious about the technical details related to showing this security warning, see the Android OS source code, specifically _ime\_security\_warning_ in the official Android source [LanguageSettings.java](https://android.googlesource.com/platform/packages/apps/Settings/+/935b504a05f328cf90db3415b82ff4a7f51e628f/src/com/android/settings/LanguageSettings.java) and [message catalog](https://android.googlesource.com/platform/packages/apps/Settings/+/935b504a05f328cf90db3415b82ff4a7f51e628f/res/values/strings.xml).
 
 ## Where's the source code? ##
 
-See "Source" link above: http://code.google.com/p/hackerskeyboard/source/browse/
+See "Source" link above: https://github.com/klausw/hackerskeyboard/blob/master/
 
 See BuildingFromSource for instructions how to build it yourself.
 
@@ -29,7 +29,7 @@ If using a phone, turn the phone sideways (landscape mode) to see the full layou
 For manual activation, use these steps:
 
   * Go to Home / Menu / Settings / Language & Keyboard
-  * Scroll down to "Hacker's Keyboard", activate the check mark, and acknowledge the system warning shown for third-party input methods. (See [this FAQ entry](http://code.google.com/p/hackerskeyboard/w/edit.do#Why_is_there_a_security_warning_when_I_activate_it?) for more information about the warning.)
+  * Scroll down to "Hacker's Keyboard", activate the check mark, and acknowledge the system warning shown for third-party input methods. (See [this FAQ entry](https://github.com/klausw/hackerskeyboard/wiki/FrequentlyAskedQuestions#why-is-there-a-security-warning-when-i-activate-it) for more information about the warning.)
   * Exit settings and open a text entry box, for example the Search bar.
   * Long-press the input field, and select the _Input method_ menu entry.
   * Select "Hacker's Keyboard" from the list.
@@ -60,7 +60,7 @@ If this is not working for you, or if you have a nonstandard device that doesn't
 
 You can configure the gesture used for this in the keyboard's "Gesture and key actions" settings menu. If the swipe action is too hard to trigger, try binding the "close keyboard" action to the "Volume down" hardware key. This won't interfere with normal use of the volume button while the keyboard is closed.
 
-For the future, I do plan to add support for a dedicated "close keyboard" key, but this needs to be part of the general user-customizable layout support ([issue 13](https://code.google.com/p/hackerskeyboard/issues/detail?id=13)) - there just isn't enough room in the current layouts to add this by default for everyone.
+For the future, I do plan to add support for a dedicated "close keyboard" key, but this needs to be part of the general user-customizable layout support ([issue 13](https://github.com/klausw/hackerskeyboard/issues/13)) - there just isn't enough room in the current layouts to add this by default for everyone.
 
 ## Where can I get a completion dictionary for my language? ##
 
@@ -83,7 +83,7 @@ I'm planning to add support for an AltGr key in a future version.
 
 The Circle key to the left of the arrow keys corresponds to pushing a trackball to make a menu selection, or pressing the middle of a directional keypad. The corresponding Android keycode is DPAD\_CENTER. This is usually equivalent to pressing RETURN, but some applications treat it differently. For example, when navigating a dropdown suggestion list such as the browser's address bar, you can use it to copy the current selection for further editing instead of immediately selecting it.
 
-As a secondary function, you can long-press the Circle key to activate a "compose" function, for example Compose (long-press Circle) followed by the "o" and "c" keys generates the "©" Copyright symbol. See the [source file](http://code.google.com/p/hackerskeyboard/source/browse/java/src/org/pocketworkstation/pckeyboard/ComposeSequence.java) for the list of supported combinations.
+As a secondary function, you can long-press the Circle key to activate a "compose" function, for example Compose (long-press Circle) followed by the "o" and "c" keys generates the "©" Copyright symbol. See the [source file](https://github.com/klausw/hackerskeyboard/blob/master/java/src/org/pocketworkstation/pckeyboard/ComposeSequence.java) for the list of supported combinations.
 
 # Bugs and known issues #
 
@@ -103,7 +103,7 @@ If this isn't working for you as described here, please let me know.
 
 ## "Touch to correct words" inserts the correction instead of replacing ##
 
-See [issue 17](https://code.google.com/p/hackerskeyboard/issues/detail?id=17), this feature depends on [operating system support](http://developer.android.com/reference/android/view/inputmethod/InputConnection.html#setComposingRegion(int,%20int)) that's only available starting with Gingerbread (v2.3). In the meantime I recommend disabling the option in the keyboard settings if it's not working correctly.
+See [issue 17](https://github.com/klausw/hackerskeyboard/issues/17), this feature depends on [operating system support](http://developer.android.com/reference/android/view/inputmethod/InputConnection.html#setComposingRegion(int,%20int)) that's only available starting with Gingerbread (v2.3). In the meantime I recommend disabling the option in the keyboard settings if it's not working correctly.
 
 ## It doesn't work right after upgrading ##
 
@@ -125,7 +125,7 @@ Recent Android versions (starting from Honeycomb / 3.0) do include support for t
 
 Support for the extra keys varies by application. The keyboard just sends key events, and the application receiving the key events is responsible for acting on them, and typically applications ignore unknown or unexpected key events, or (in unfortunate cases) misinterpret the keystrokes to launch menu shortcuts or similar.
 
-If possible, try attaching a USB or Bluetooth keyboard to your Android device to see if the corresponding keys work with a real hardware keyboard. If that also doesn't work, it'll most likely require a change to the application before a soft keyboard such as this one can support them. If it works with a real keyboard but not with the Hacker's Keyboard application, please [file a bug](http://code.google.com/p/hackerskeyboard/issues/list).
+If possible, try attaching a USB or Bluetooth keyboard to your Android device to see if the corresponding keys work with a real hardware keyboard. If that also doesn't work, it'll most likely require a change to the application before a soft keyboard such as this one can support them. If it works with a real keyboard but not with the Hacker's Keyboard application, please [file a bug](https://github.com/klausw/hackerskeyboard/issues).
 
 Developers: see KeyboardSupportInApplications for more information.
 
@@ -133,7 +133,7 @@ Developers: see KeyboardSupportInApplications for more information.
 
 You can send a crash report through the Android crash reporting tool, this will give me some basic anonymized data about the crash location and an indication how often a problem occurs, but isn't always sufficient to figure out what's going on. If possible, please include details how to reproduce it, and information about your phone and Android version, those aren't included in the automatic report. If you want me to respond, please make sure to include your email address in the text.
 
-It's easiest for me to handle if you [file a bug](http://code.google.com/p/hackerskeyboard/issues/list), that helps avoid losing track of things and lets me easily send progress updates. You can also just send me email if you don't want to use the issue tracker.
+It's easiest for me to handle if you [file a bug](https://github.com/klausw/hackerskeyboard/issues), that helps avoid losing track of things and lets me easily send progress updates. You can also just send me email if you don't want to use the issue tracker.
 
 For crashes and similar issues, I'll most likely need system log information to figure out what's going on if I can't reproduce the bug.
 See HowToAccessSystemLogData for more information how to get this data from your phone.
@@ -189,14 +189,14 @@ Obsolete text following:
 
 > It uses the contacts information for completion of names and email addresses, and audio recording for the voice input feature.
 
-> I'm considering making a minimal-permissions version with this code disabled if there's sufficient demand, see http://code.google.com/p/hackerskeyboard/issues/detail?id=2 for more details.
+> I'm considering making a minimal-permissions version with this code disabled if there's sufficient demand, see https://github.com/klausw/hackerskeyboard/issues/2 for more details.
 
 ## Why does it ask for "call log" permission? ##
 
 Current versions (1.37) should no longer be showing this spurious permission request.
 
 Obsolete text following:
-> This is a temporary side effect of a recent change in Android permissions that appears on 4.1 (Jellybean) devices. I'll need to build and publish a new version to fix this, if you want this earlier you can download one of the release candidates from https://code.google.com/p/hackerskeyboard/downloads/list which includes a fix for this.
+> This is a temporary side effect of a recent change in Android permissions that appears on 4.1 (Jellybean) devices. I'll need to build and publish a new version to fix this, if you want this earlier you can download one of the release candidates from https://github.com/klausw/hackerskeyboard/releases which includes a fix for this.
 
 > The application is not actively asking for the READ\_CALL\_LOG permission. The equivalent rights were granted automatically on older Android versions when asking for READ\_CONTACTS, and recent versions split this up into two separate permissions. To avoid breaking backwards compatibility, apps requesting READ\_CONTACTS are automatically treated as also asking for READ\_CALL\_LOG unless they explicitly declare that they are aware of this distinction by setting the API level. I'll need to rebuild it with a current SDK to remove this permission, thanks for pointing that out.
 

--- a/ProjectHome.md
+++ b/ProjectHome.md
@@ -12,7 +12,7 @@ To install, get **[Hacker's Keyboard](https://market.android.com/details?id=org.
 
 See the **ReleaseNotes** for changes in the Play Store released versions, and follow the project on **[Google+](https://plus.google.com/100683221734778417816)** for news and updates including pre-release versions.
 
-Having problems? See the **UsersGuide** and **FrequentlyAskedQuestions**, and check the [issue tracker](http://code.google.com/p/hackerskeyboard/issues/list) for known bugs or filing new ones.
+Having problems? See the **UsersGuide** and **FrequentlyAskedQuestions**, and check the [issue tracker](https://github.com/klausw/hackerskeyboard/issues) for known bugs or filing new ones.
 
 Comments, requests, or contributions? Join the [discussion group](http://groups.google.com/group/hackerskeyboard/).
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,9 +4,8 @@
 
 This page summarizes the changes between the Hacker's Keyboard releases on
 Android Market. For non-Market pre-release versions, see the
-[Downloads](http://code.google.com/p/hackerskeyboard/downloads/list) page. The
-code-level change descriptions are available in the
-[Source](http://code.google.com/p/hackerskeyboard/source/list) area.
+[Releases](https://github.com/klausw/hackerskeyboard/releases) page. The
+code-level change descriptions are available in the same area.
 
 If you notice problems or regressions in a Market release, please contact me directly by email or file a bug. I don't get notified for problems reported in Market reviews, and I can't contact the comment author or respond to them, which is especially frustrating for cases where a simple configuration change would fix things.
 
@@ -20,7 +19,7 @@ Major changes:
   * Add Google Cloud settings backup support.
 
 New settings:
-  * Support choice of Shift Lock or Caps Lock, optionally apply Shift Lock to special keys. ([Issue 177](https://code.google.com/p/hackerskeyboard/issues/detail?id=177))
+  * Support choice of Shift Lock or Caps Lock, optionally apply Shift Lock to special keys. ([Issue 177](https://github.com/klausw/hackerskeyboard/issues/177))
 
 New layouts:
 
@@ -28,7 +27,7 @@ New layouts:
   * "ta" (Tamil, தமிழ்) 5-row layout. Contributed by "Stars Soft".
   * "Español (Latinoamérica)" 5-row layout, contributed by Miguel Farah
 
-For more details, please see the [prerelease notes](https://code.google.com/p/hackerskeyboard/downloads/detail?name=hackerskeyboard-v1034rc17.apk).
+For more details, please see the [prerelease notes](https://github.com/klausw/hackerskeyboard/releases/tag/1.34rc17).
 
 ## Version 1.33 ##
 
@@ -46,21 +45,21 @@ New layouts:
 This is primarily a bugfix release, no notable new features.
 
 ### Layout modifications ###
-  * update Portugese 5-row altchars, [issue 191](https://code.google.com/p/hackerskeyboard/issues/detail?id=191)
-  * add Latvian alt chars, [issue 176](https://code.google.com/p/hackerskeyboard/issues/detail?id=176)
+  * update Portugese 5-row altchars, [issue 191](https://github.com/klausw/hackerskeyboard/issues/191)
+  * add Latvian alt chars, [issue 176](https://github.com/klausw/hackerskeyboard/issues/176)
   * Add missing ľ and ĺ altchars for Slovak (SK)
-  * Remove unwanted letter hints in Hebrew and other non-latin keyboards, [issue 159](https://code.google.com/p/hackerskeyboard/issues/detail?id=159)
+  * Remove unwanted letter hints in Hebrew and other non-latin keyboards, [issue 159](https://github.com/klausw/hackerskeyboard/issues/159)
 
 ### Other changes ###
   * disable auto space after completion for Thai
-  * New options for slide key events, see [issue 167](https://code.google.com/p/hackerskeyboard/issues/detail?id=167)
+  * New options for slide key events, see [issue 167](https://github.com/klausw/hackerskeyboard/issues/167)
   * make swipe gesture easier to trigger
 
 ### Bugfixes ###
-  * fix Ctrl modifier that was getting stuck, [issue 165](https://code.google.com/p/hackerskeyboard/issues/detail?id=165)
-  * fix landscape keyboard layout preference, [issue 175](https://code.google.com/p/hackerskeyboard/issues/detail?id=175)
-  * fix suggestion preference handling, [issue 182](https://code.google.com/p/hackerskeyboard/issues/detail?id=182)
-  * disable "slide key hack" for popup keyboards, [issue 187](https://code.google.com/p/hackerskeyboard/issues/detail?id=187)
+  * fix Ctrl modifier that was getting stuck, [issue 165](https://github.com/klausw/hackerskeyboard/issues/165)
+  * fix landscape keyboard layout preference, [issue 175](https://github.com/klausw/hackerskeyboard/issues/175)
+  * fix suggestion preference handling, [issue 182](https://github.com/klausw/hackerskeyboard/issues/182)
+  * disable "slide key hack" for popup keyboards, [issue 187](https://github.com/klausw/hackerskeyboard/issues/187)
   * Workarounds for null pointer exceptions in UserDictionary and isConnectbot()
 
 ## Version 1.29 ##
@@ -98,9 +97,9 @@ This is primarily a bugfix release, no notable new features.
 ### Bugfixes ###
 
   * Completion of words beginning with a capital letter was not working correctly in 5-row mode.
-  * Fix Hebrew layouts on Samsung Galaxy S2 ([issue 122](https://code.google.com/p/hackerskeyboard/issues/detail?id=122))
-  * Add VX ConnectBot support for the compatibility hack ([issue 154](https://code.google.com/p/hackerskeyboard/issues/detail?id=154))
-  * New "Sliding key events" option as a workaround for [issue 53](https://code.google.com/p/hackerskeyboard/issues/detail?id=53) "Keyboard drops characters if I type too fast"
+  * Fix Hebrew layouts on Samsung Galaxy S2 ([issue 122](https://github.com/klausw/hackerskeyboard/issues/122))
+  * Add VX ConnectBot support for the compatibility hack ([issue 154](https://github.com/klausw/hackerskeyboard/issues/154))
+  * New "Sliding key events" option as a workaround for [issue 53](https://github.com/klausw/hackerskeyboard/issues/53) "Keyboard drops characters if I type too fast"
 
 
 ### Experimental features ###
@@ -118,6 +117,6 @@ experiments.
     * In "Theme and label settings", check "Enable compact 5-row keyboard mode"
     * Exit and re-enter keyboard settings (known bug, the new mode isn't visible unless you do this)
     * In "Keyboard view settings", change the "Keyboard mode" to "5-row compact layout" for portrait and/or landscape.
-    * Screenshot, with number row scaling set to 80%: ![http://hackerskeyboard.googlecode.com/files/hk-5row-compact-s.png](http://hackerskeyboard.googlecode.com/files/hk-5row-compact-s.png)
+    * Screenshot, with number row scaling set to 80%: ![https://raw.githubusercontent.com/klausw/hackerskeyboard/master/hk-5row-en-s.png](https://raw.githubusercontent.com/klausw/hackerskeyboard/master/hk-5row-en-s.png)
 
   * Extension keyboards for some layouts, for example adding numbers+punctuation in 4-row mode and F1-F12 in 5-row mode. Toggle the extension with a gesture action, "swipe up" by default.

--- a/UsersGuide.md
+++ b/UsersGuide.md
@@ -33,7 +33,7 @@ The "Fn" key shows an alternate keymap with additional special keys including Ho
 
 The arrow keys in the bottom right corner generate directional pad (trackball) key events.
 
-The "◯" (circle) key next to the arrows corresponds to pressing the directional pad center button. Long-pressing "◯" acts as a "compose" key, for example the sequence "◯" "+" "-" produces "±". See the [source](https://code.google.com/p/hackerskeyboard/source/browse/java/src/org/pocketworkstation/pckeyboard/ComposeSequence.java) for a list of supported combinations.
+The "◯" (circle) key next to the arrows corresponds to pressing the directional pad center button. Long-pressing "◯" acts as a "compose" key, for example the sequence "◯" "+" "-" produces "±". See the [source](https://github.com/klausw/hackerskeyboard/blob/master/java/src/org/pocketworkstation/pckeyboard/ComposeSequence.java) for a list of supported combinations.
 
 ## Configuration options ##
 


### PR DESCRIPTION
This PR updates the links pointing to code.google (source, issues, Wiki) to this repository in the different Wiki pages.

As GitHub does not seem to allow PR for the Wiki and you had a Wiki branch in your repository, here it is. Unfortunately, you'll still need to copy the files manually to the Wiki repository ... If you would prefer these changes an another way, I can probably adapt it.