### PR TITLE
Restrict buffer access within bounds

### DIFF
--- a/app/src/main/cpp/dictionary.cpp
+++ b/app/src/main/cpp/dictionary.cpp
@@ -72,7 +72,10 @@ int Dictionary::getSuggestions(int *codes, int codesSize, unsigned short *outWor
 
     // Get the word count
     suggWords = 0;
-    while (suggWords < mMaxWords && mFrequencies[suggWords] > 0) suggWords++;
+    while (suggWords < mMaxWords && sizeof(mFrequencies) < suggWords-1 &&
+        mFrequencies[suggWords] > 0) {
+            suggWords++;
+    }
     if (DEBUG_DICT) LOGI("Returning %d words", suggWords);
 
     if (DEBUG_DICT) {


### PR DESCRIPTION
This PR will restrict array access within bounds to avoid overflow issues.